### PR TITLE
Add validation for the generate subcommand

### DIFF
--- a/src/generate_conf.rs
+++ b/src/generate_conf.rs
@@ -9,8 +9,8 @@ use nmstate::{InterfaceType, NetworkState};
 use crate::types::{Host, Interface};
 use crate::HOST_MAPPING_FILE;
 
-/// NetworkConfig contains the generated configurations in the
-/// following format: Vec<(config_file_name, config_content>)
+/// `NetworkConfig` contains the generated configurations in the
+/// following format: `Vec<(config_file_name, config_content>)`
 type NetworkConfig = Vec<(String, String)>;
 
 /// Generate network configurations from all YAML files in the `config_dir`
@@ -30,7 +30,7 @@ pub(crate) fn generate(config_dir: &str, output_dir: &str) -> Result<(), anyhow:
         let hostname = extract_hostname(&path)
             .and_then(OsStr::to_str)
             .ok_or_else(|| anyhow!("Invalid file path"))?
-            .to_string();
+            .to_owned();
 
         let data = fs::read_to_string(&path).context("Reading network config")?;
 
@@ -72,7 +72,7 @@ fn extract_interfaces(network_state: &NetworkState) -> Vec<Interface> {
         .iter()
         .filter(|i| i.iface_type() != InterfaceType::Loopback)
         .map(|i| Interface {
-            logical_name: i.name().to_string(),
+            logical_name: i.name().to_owned(),
             mac_address: i.base_iface().mac_address.clone(),
             interface_type: i.iface_type().to_string(),
         })

--- a/src/generate_conf.rs
+++ b/src/generate_conf.rs
@@ -16,6 +16,10 @@ type NetworkConfig = Vec<(String, String)>;
 /// Generate network configurations from all YAML files in the `config_dir`
 /// and store the result *.nmconnection files and host mapping under `output_dir`.
 pub(crate) fn generate(config_dir: &str, output_dir: &str) -> Result<(), anyhow::Error> {
+    if fs::read_dir(config_dir)?.count() == 0 {
+        return Err(anyhow!("Empty config directory"));
+    };
+
     for entry in fs::read_dir(config_dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -164,6 +168,16 @@ mod tests {
         fs::remove_dir_all(out_dir)?;
 
         Ok(())
+    }
+
+    #[test]
+    fn generate_fails_due_to_empty_dir() {
+        fs::create_dir_all("empty").unwrap();
+
+        let error = generate("empty", "_out").unwrap_err();
+        assert_eq!(error.to_string(), "Empty config directory");
+
+        fs::remove_dir_all("empty").unwrap();
     }
 
     #[test]

--- a/src/generate_conf.rs
+++ b/src/generate_conf.rs
@@ -323,6 +323,29 @@ mod tests {
     }
 
     #[test]
+    fn validate_interfaces_successfully() {
+        let interfaces = vec![
+            Interface {
+                logical_name: "eth0".to_string(),
+                mac_address: Option::from("00:11:22:33:44:55".to_string()),
+                interface_type: "ethernet".to_string(),
+            },
+            Interface {
+                logical_name: "eth0.1365".to_string(),
+                mac_address: None,
+                interface_type: "vlan".to_string(),
+            },
+            Interface {
+                logical_name: "bond0".to_string(),
+                mac_address: None,
+                interface_type: "bond".to_string(),
+            },
+        ];
+
+        assert!(validate_interfaces(&interfaces).is_ok())
+    }
+
+    #[test]
     fn extract_host_name() {
         assert_eq!(extract_hostname("".as_ref()), None);
         assert_eq!(extract_hostname("node1".as_ref()), Some("node1".as_ref()));


### PR DESCRIPTION
- Introduces basic validation that:
  - The config directory is not empty
  - The Ethernet interfaces are assigned MAC addresses
- Closes https://github.com/suse-edge/nm-configurator/issues/10