### PR TITLE
Bump Rust to v1.74

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/rust:1.73
+FROM registry.suse.com/bci/rust:1.74
 
 COPY . /
 WORKDIR /


### PR DESCRIPTION
- Updates the release Dockerfile to use Rust v1.74 base image