### PR TITLE
Set truncate mode for conn files

### DIFF
--- a/src/apply_conf.rs
+++ b/src/apply_conf.rs
@@ -148,6 +148,7 @@ fn copy_connection_files(
 
         fs::OpenOptions::new()
             .create(true)
+            .truncate(true)
             .write(true)
             .mode(0o600)
             .open(&destination)


### PR DESCRIPTION
- Fixes linter issue:
  ```
  error: file opened with `create`, but `truncate` behavior not defined
  ```